### PR TITLE
Fix rest client version mismatch.

### DIFF
--- a/src/main/resources/templates/parent-pom.xml
+++ b/src/main/resources/templates/parent-pom.xml
@@ -51,6 +51,15 @@
 	</dependencyManagement>
 {{/hasBoms}}
 
+	<!-- Fix mismatched rest client version in cloud (1.3.1) and boot (1.0.0) -->
+	<dependencies>
+		<dependency>
+			<groupId>com.microsoft.rest</groupId>
+			<artifactId>client-runtime</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
* Azure rest client version in cloud (1.3.1) and boot (1.0.0).

Signed-off-by: Pan Li <panli@microsoft.com>