### PR TITLE
Fix cache services

### DIFF
--- a/src/main/resources/static/js/start.js
+++ b/src/main/resources/static/js/start.js
@@ -518,16 +518,26 @@ $(function () {
         setInputValue($("#description"), pageStorage.getDescription());
         checkInfraModules(pageStorage.getSelectedInfraModules());
 
+        // Initialize already selected infra services
+        infraCheckbox.each(function(){
+            updateInfraService($(this), false);
+        });
+
         var storedServices = pageStorage.getMicroServices();
         if (Array.isArray(storedServices) && storedServices.length) {
             // Load stored microservices from localstorage
             $.each(storedServices, function(index, service) {
-                addServiceOnPage(new microservice(service['name'], service['modules'], service['port'], service['deletable']));
-            });
-        } else {
-            // Initialize already selected infra services
-            infraCheckbox.each(function(){
-                updateInfraService($(this), false);
+                var microservice = new microservice(service['name'], service['modules'], service['port'], service['deletable']);
+
+                var matchedServices = allServiceList.serviceList.filter(function(service) {
+                    return service.getName() === microservice.getName();
+                });
+
+                if (matchedServices) {
+                    deleteServiceOnPage(microservice.getName())
+                }
+
+                addServiceOnPage(microservice);
             });
         }
     });

--- a/src/main/resources/static/js/start.js
+++ b/src/main/resources/static/js/start.js
@@ -510,7 +510,8 @@ $(function () {
         pageStorage.setPageStatus(pageStatus);
     });
 
-    $(window).on('load', function(){
+    (function() {
+        // Initialize page when page ready, load data from localStorage
         setActiveStep(pageStorage.getStep());
         setInputValue($("#project-name"), pageStorage.getProjectName());
         setInputValue($("#groupId"), pageStorage.getGroupId());
@@ -525,20 +526,20 @@ $(function () {
 
         var storedServices = pageStorage.getMicroServices();
         if (Array.isArray(storedServices) && storedServices.length) {
-            // Load stored microservices from localstorage
+            // Load stored microservices from localStorage
             $.each(storedServices, function(index, service) {
-                var microservice = new microservice(service['name'], service['modules'], service['port'], service['deletable']);
+                var _microservice = new microservice(service['name'], service['modules'], service['port'], service['deletable']);
 
                 var matchedServices = allServiceList.serviceList.filter(function(service) {
-                    return service.getName() === microservice.getName();
+                    return service.getName() === _microservice.getName();
                 });
 
                 if (matchedServices) {
-                    deleteServiceOnPage(microservice.getName())
+                    deleteServiceOnPage(_microservice.getName())
                 }
 
-                addServiceOnPage(microservice);
+                addServiceOnPage(_microservice);
             });
         }
-    });
+    })();
 });


### PR DESCRIPTION
Fix 2 issues:
* If localStorage stored must select infra modules are incorrect, the must selected modules will not be initialized correctly, as the localStorage stored data takes priority 

* Previously page status is initialized in load event, which can be blocked by other Javascript file loading status